### PR TITLE
FEAT:로그인여부에 따른 라우트 분기

### DIFF
--- a/FE/src/App.jsx
+++ b/FE/src/App.jsx
@@ -1,23 +1,44 @@
 import { useState } from "react";
 import "./App.css";
-import Auth from "./pages/auth/Auth";
-import CompanyList from "./pages/company/list";
 import InvestmentList from "./pages/investment/list";
 import "./styles/table.css";
 import Result from "./pages/compare/result";
 import Header from "./components/layout/header";
 import CompanyPage from "./pages/company/CompanyPage";
 import { Routes, Route, Navigate } from "react-router-dom";
+import ProtectedLayout from "./components/layout/ProtextedLayout";
+import Auth from "./pages/auth/Auth";
 
 function App() {
   return (
     <>
       <Header />
-      <Auth />
       <Routes>
-        <Route path="/" element={<CompanyPage />} />
-        <Route path="/investments" element={<InvestmentList />} />
-        <Route path="/compare" element={<Result />} />
+        <Route
+          path="/"
+          element={
+            <ProtectedLayout title="전체 스타트업 목록">
+              <CompanyPage />
+            </ProtectedLayout>
+          }
+        />
+        <Route
+          path="/investments"
+          element={
+            <ProtectedLayout title="투자 현황">
+              <InvestmentList />
+            </ProtectedLayout>
+          }
+        />
+        <Route
+          path="/compare"
+          element={
+            <ProtectedLayout title="비교 현황">
+              <Result />
+            </ProtectedLayout>
+          }
+        />
+        <Route path="/auth" element={<Auth />} />
       </Routes>
     </>
   );

--- a/FE/src/components/layout/ProtextedLayout.jsx
+++ b/FE/src/components/layout/ProtextedLayout.jsx
@@ -1,0 +1,15 @@
+import { Navigate } from "react-router-dom";
+import Layout from "./layout";
+import { getStoredUser } from "../../pages/auth/Auth";
+
+const ProtectedLayout = ({ title, children }) => {
+  const user = getStoredUser();
+
+  if (!user) {
+    return <Navigate to="/auth" replace />;
+  }
+
+  return <Layout title={title}>{children}</Layout>;
+};
+
+export default ProtectedLayout;

--- a/FE/src/components/layout/header.css
+++ b/FE/src/components/layout/header.css
@@ -33,3 +33,7 @@
   line-height: normal;
   text-decoration: none;
 }
+
+.header-menu-name.active {
+  color: #ffffff;
+}

--- a/FE/src/components/layout/header.jsx
+++ b/FE/src/components/layout/header.jsx
@@ -2,21 +2,24 @@ import React from "react";
 import "./header.css";
 import "../../../react.css";
 import logo from "./img/logo1.png";
+import { Link, NavLink } from "react-router-dom";
 function Header() {
   return (
     <header>
       <div className="header-array">
-        <img src={logo} alt="View my startup" className="header-logo" />
+        <Link to="/">
+          <img src={logo} alt="View my startup" className="header-logo" />
+        </Link>
         <div className="header-menu-interval">
-          <a href="/" className="header-menu-name">
+          <NavLink to="/" end className="header-menu-name">
             나의 기업 비교
-          </a>
-          <a href="/" className="header-menu-name">
+          </NavLink>
+          <NavLink to="/compare" className="header-menu-name">
             비교 현황
-          </a>
-          <a href="/" className="header-menu-name">
+          </NavLink>
+          <NavLink to="/investments" className="header-menu-name">
             투자 현황
-          </a>
+          </NavLink>
         </div>
       </div>
     </header>

--- a/FE/src/pages/compare/result.jsx
+++ b/FE/src/pages/compare/result.jsx
@@ -112,13 +112,11 @@ const Result = () => {
   const sortedList = [...companyList].sort((a, b) => b.revenue - a.revenue);
   return (
     <>
-      <section>
-        <h3>내가 선택한 기업</h3>
-        {/* 기업추가 카드 들어갈 자리 */}
+      {/* <section>
+        기업추가 카드 들어갈 자리
         <CompareCard />
-      </section>
+      </section> */}
       <section>
-        <h3>비교 결과 확인하기</h3>
         <table className="startup-table mb-4">
           <thead className="startup-table-head">
             <tr>


### PR DESCRIPTION
## 📌 개요

- 로그인 여부에 따른 라우팅 분기 처리 및 헤더 네비게이션 개선 작업을 진행했습니다.

---

## ✨ 작업 내용

- 로그인 여부에 따라 접근 가능한 페이지 분기 처리 구현
- 로그인 상태일 경우 리스트 페이지 노출, 비로그인 시 로그인 페이지로 리다이렉트 처리
- 헤더 메뉴를 a 태그에서 NavLink로 변경
- 현재 경로(active)에 따른 스타일 적용

---

## 🔧 변경 사항

- App.jsx에 라우트 구성 및 로그인 여부 분기 로직 추가
- 기존 a 태그 기반 링크를 NavLink로 변경하여 active 상태 자동 관리
- active 상태에 따른 CSS 스타일 추가
- 로그인 상태 확인을 위한 localStorage 기반 처리 적용

---

## 🧪 테스트 방법

- 로그인 상태에서 "/" 접속 시 리스트 페이지 정상 출력 확인
- 비로그인 상태에서 "/" 접속 시 "/auth"로 리다이렉트 확인
- 헤더 메뉴 클릭 시 라우팅 정상 동작 확인
- 현재 경로에 따라 active 스타일 적용 여부 확인

---


## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 에러 없음
- [x] 콘솔 경고 없음
- [x] 코드 컨벤션 준수
- [x] PR 제목 컨벤션 준수

---

## 🔗 관련 이슈

- close # (이슈 번호 입력) #17 