### PR TITLE
Feat: 기업상세 api연결

### DIFF
--- a/FE/src/pages/company/CompanyPage.jsx
+++ b/FE/src/pages/company/CompanyPage.jsx
@@ -15,16 +15,24 @@ const CompanyPage = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      const res = await fetch(
-        `http://localhost:8080/companies?page=${currentPage}&limit=10`,
-      );
-      const result = await res.json();
+      try {
+        const res = await fetch(
+          `http://localhost:8080/companies?page=${currentPage}&limit=10`,
+        );
 
-      setCompanyList(result.data || []);
-      setMeta(result.meta || {});
+        if (!res.ok) {
+          throw new Error(`API 오류: ${res.status}`);
+        }
 
-      console.log(companyList);
+        const result = await res.json();
+
+        setCompanyList(result.data || []);
+        setMeta(result.meta || {});
+      } catch (err) {
+        console.error("회사 목록 조회 실패:", err);
+      }
     };
+
     fetchData();
   }, [currentPage]);
 

--- a/FE/src/pages/company/CompanyPage.jsx
+++ b/FE/src/pages/company/CompanyPage.jsx
@@ -4,6 +4,7 @@ import Pagination from "../../components/pagination/Pagination";
 import "../../styles/pagination.css";
 
 const CompanyPage = () => {
+  const [loading, setLoading] = useState(true);
   const [companyList, setCompanyList] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [meta, setMeta] = useState({
@@ -16,6 +17,8 @@ const CompanyPage = () => {
   useEffect(() => {
     const fetchData = async () => {
       try {
+        setLoading(true);
+
         const res = await fetch(
           `http://localhost:8080/companies?page=${currentPage}&limit=10`,
         );
@@ -30,11 +33,17 @@ const CompanyPage = () => {
         setMeta(result.meta || {});
       } catch (err) {
         console.error("회사 목록 조회 실패:", err);
+      } finally {
+        setLoading(false);
       }
     };
 
     fetchData();
   }, [currentPage]);
+
+  if (loading) {
+    return <div style={{ color: "red" }}>로딩 중...</div>;
+  }
 
   return (
     <>

--- a/FE/src/pages/company/detail.jsx
+++ b/FE/src/pages/company/detail.jsx
@@ -34,6 +34,14 @@ const Detail = () => {
           ),
         ]);
 
+        if (!companyRes.ok) {
+          throw new Error(`회사 API 오류: ${companyRes.status}`);
+        }
+
+        if (!investmentRes.ok) {
+          throw new Error(`투자 API 오류: ${investmentRes.status}`);
+        }
+
         const companyData = await companyRes.json();
         const investmentData = await investmentRes.json();
 

--- a/FE/src/pages/company/detail.jsx
+++ b/FE/src/pages/company/detail.jsx
@@ -1,82 +1,13 @@
 import React, { useEffect, useState } from "react";
 import { useParams } from "react-router-dom";
 import "../../styles/companyDetail.css";
-
-const mockCompanyDetail = {
-  id: 1,
-  name: "코드잇",
-  category: "에듀테크",
-  logo: "https://cdn.brandfetch.io/google.com?c=1idkDO95bvic4Gu9Oty",
-  totalInvestment: "140억 원",
-  revenue: "44.3억 원",
-  employeeCount: "95명",
-  description: `코드잇은 온라인 코딩 교육 서비스를 운영하는 EdTech 스타트업입니다.
-
-코딩 교육과 데이터 사이언스 교육에 대한 수요는 급격히 늘어나고 있지만, 아직까지 좋은 교육 서비스를 찾기란 쉽지 않습니다. 이를 해결하고자 코드잇은 모든 강의를 자체 제작하여 퀄리티 높은 콘텐츠를 제공하고, 동시에 코딩 교육에 최적화된 플랫폼을 개발하고 있습니다.
-
-모든 강의를 마음껏 들을 수 있는 "코드잇 무제한 멤버십"을 제공하고 있으며, 지난 5년 동안 21만 명의 수강생과 평균 만족도 4.9점이라는 국내 교육 업계에서 보기 드문 성과를 달성하였습니다. 또한 콘텐츠와 기술력을 인정받아 2021년 10월 Series B 투자를 받아 누적 140억 원의 투자를 받았고, 현재 40여 명의 팀원이 같은 목표를 향해 나아가고 있습니다.
-
-"배움의 기쁨을 세상 모두에게."
-
-이것이 코드잇의 비전입니다. 현재는 최고의 코딩 교육 서비스를 국내에서 제공하고 있지만, 이보다 더 큰 그림을 그리고 있습니다. 2021년 상반기부터 영어권 시장 진출을 시작했고, 코딩과 인접한 분야부터 스펙트럼을 넓혀 나갈 계획입니다.`,
-  receivedInvestmentTotal: "총 200억 원",
-  investments: [
-    {
-      id: 1,
-      investorName: "김연우",
-      rank: 1,
-      amount: "10억",
-      comment: "코드잇은 정말 훌륭한 기업입니다!",
-    },
-    {
-      id: 2,
-      investorName: "이유지",
-      rank: 2,
-      amount: "9억",
-      comment: "코드잇의 성장 가능성은 무궁무진합니다!",
-    },
-    {
-      id: 3,
-      investorName: "안다혜",
-      rank: 3,
-      amount: "8억",
-      comment: "최고의 기업! 코드잇!",
-    },
-    {
-      id: 4,
-      investorName: "신희성",
-      rank: 4,
-      amount: "7억",
-      comment: "코드잇의 진출 분야는 무궁무진합니다.",
-    },
-    {
-      id: 5,
-      investorName: "이용섭",
-      rank: 5,
-      amount: "6억",
-      comment: "교육업계의 라이징 스타 코드잇을 신뢰합니다.",
-    },
-    {
-      id: 6,
-      investorName: "박지훈",
-      rank: 6,
-      amount: "5억",
-      comment: "장기적으로 더 크게 성장할 것 같습니다.",
-    },
-    {
-      id: 7,
-      investorName: "최서연",
-      rank: 7,
-      amount: "4억",
-      comment: "서비스 방향성과 팀이 인상적입니다.",
-    },
-  ],
-};
+import Button from "../../components/ui/Button";
+import Pagination from "../../components/pagination/Pagination";
 
 const Detail = () => {
-  const [companyDetail, setCompanyDetail] = useState({
-    investments: [],
-  });
+  const [loading, setLoading] = useState(true);
+  const [companyDetail, setCompanyDetail] = useState({});
+  const [investmentList, setInvestmentList] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [meta, setMeta] = useState({
     page: 1,
@@ -89,22 +20,41 @@ const Detail = () => {
 
   const userId = 1; // 임시고정
 
+  console.log(id);
+
   useEffect(() => {
-    setCompanyDetail(mockCompanyDetail);
-    // const fetchData = async () => {
-    //   const res = await fetch(
-    //     `http://localhost:8080/companies/${id}?userId=${userId}`,
-    //   );
+    const fetchData = async () => {
+      try {
+        setLoading(true);
 
-    //   const data = await res.json();
-    //   console.log(data);
-    //   setCompanyDetail(data.data);
-    // };
-    // fetchData();
-  }, [id, userId]);
+        const [companyRes, investmentRes] = await Promise.all([
+          fetch(`http://localhost:8080/companies/${id}`),
+          fetch(
+            `http://localhost:8080/companies/${id}/investments?page=${currentPage}&limit=10`,
+          ),
+        ]);
 
-  if (!companyDetail) {
-    return <div>로딩 중...</div>;
+        const companyData = await companyRes.json();
+        const investmentData = await investmentRes.json();
+
+        console.log(companyData);
+        console.log(investmentData);
+
+        setCompanyDetail(companyData.data || {});
+        setInvestmentList(investmentData.data || []);
+        setMeta(investmentData.meta || {});
+      } catch (err) {
+        console.error(err);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [id, currentPage]);
+
+  if (loading) {
+    return <div style={{ color: "red" }}>로딩 중...</div>;
   }
 
   return (
@@ -126,19 +76,21 @@ const Detail = () => {
         <div className="detail-card">
           <span className="detail-card-label">누적 투자 금액</span>
           <strong className="detail-card-value">
-            {companyDetail.totalInvestment}
+            {companyDetail?.baseInvestment?.toLocaleString()} 원
           </strong>
         </div>
 
         <div className="detail-card">
           <span className="detail-card-label">매출액</span>
-          <strong className="detail-card-value">{companyDetail.revenue}</strong>
+          <strong className="detail-card-value">
+            {companyDetail?.revenue?.toLocaleString() ?? 0} 원
+          </strong>
         </div>
 
         <div className="detail-card">
           <span className="detail-card-label">고용 인원</span>
           <strong className="detail-card-value">
-            {companyDetail.employeeCount}
+            {companyDetail.employeeCount} 명
           </strong>
         </div>
       </section>
@@ -152,11 +104,13 @@ const Detail = () => {
           <h2 className="detail-section-title">
             View My Startup에서 받은 투자
           </h2>
-          <button className="detail-invest-button">기업투자하기</button>
+          <Button type="Button-large" variant="Button-primary">
+            기업 투자하기
+          </Button>
         </div>
 
         <h3 className="detail-investment-total">
-          {companyDetail.receivedInvestmentTotal}
+          {companyDetail.siteInvestment} 원
         </h3>
 
         {/* 테이블 헤더 */}
@@ -169,16 +123,27 @@ const Detail = () => {
 
         {/* 리스트 */}
         <div className="detail-investment-list">
-          {companyDetail.investments?.map((item) => (
-            <div key={item.id} className="detail-investment-item">
-              <span className="detail-investor-name">{item.investorName}</span>
-              <span className="detail-invest-rank">{item.rank}위</span>
-              <span className="detail-invest-amount">{item.amount}</span>
-              <span className="detail-invest-comment">{item.comment}</span>
-            </div>
-          ))}
+          {!investmentList?.length ? (
+            <div className="empty-investment">투자내역이 존재하지 않습니다</div>
+          ) : (
+            investmentList.map((item) => (
+              <div key={item.id} className="detail-investment-item">
+                <span className="detail-investor-name">{item.userName}</span>
+                <span className="detail-invest-rank">{item.rank}위</span>
+                <span className="detail-invest-amount">
+                  {item?.amount?.toLocaleString()}원
+                </span>
+                <span className="detail-invest-comment">{item.comment}</span>
+              </div>
+            ))
+          )}
         </div>
       </section>
+      <Pagination
+        currentPage={meta.page}
+        totalPages={meta.totalPages}
+        onPageChange={setCurrentPage}
+      />
     </>
   );
 };

--- a/FE/src/pages/investment/InvestmentPage.jsx
+++ b/FE/src/pages/investment/InvestmentPage.jsx
@@ -3,6 +3,7 @@ import List from "./list";
 import Pagination from "../../components/pagination/Pagination";
 
 const InvestmentPage = () => {
+  const [loading, setLoading] = useState(true);
   const [investmentList, setInvestmentList] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
   const [meta, setMeta] = useState({
@@ -14,18 +15,34 @@ const InvestmentPage = () => {
 
   useEffect(() => {
     const fetchData = async () => {
-      const res = await fetch(
-        `http://localhost:8080/companies?page=${currentPage}&limit=10`,
-      );
+      try {
+        setLoading(true);
 
-      const result = await res.json();
+        const res = await fetch(
+          `http://localhost:8080/companies?page=${currentPage}&limit=10`,
+        );
 
-      setInvestmentList(result.data || []);
-      setMeta(result.meta || {});
+        if (!res.ok) {
+          throw new Error(`API 오류: ${res.status}`);
+        }
+
+        const result = await res.json();
+
+        setInvestmentList(result.data || []);
+        setMeta(result.meta || {});
+      } catch (err) {
+        console.error("데이터 조회 실패:", err);
+      } finally {
+        setLoading(false);
+      }
     };
 
     fetchData();
   }, [currentPage]);
+
+  if (loading) {
+    return <div style={{ color: "red" }}>로딩 중...</div>;
+  }
 
   return (
     <>

--- a/FE/src/styles/companyDetail.css
+++ b/FE/src/styles/companyDetail.css
@@ -177,6 +177,17 @@
   color: #d1d1d1;
 }
 
+.empty-investment {
+  display: grid;
+  justify-content: center;
+  align-items: center;
+  padding: 26px 20px;
+  border-bottom: 1px solid #2a2a2a;
+  background: var(--black-black_200, #212121);
+  font-size: 17px;
+  color: #f1f1f1;
+}
+
 @media (max-width: 1024px) {
   .detail-summary {
     grid-template-columns: 1fr;


### PR DESCRIPTION
## 📌 개요

기업 상세페이지에서 기업 정보와 투자 정보를 API를 통해 조회하여 화면에 렌더링하고, 리스트 페이지에 로딩 및 에러 처리를 추가합니다.

- ***

## ✨ 작업 내용

- `/companies/:id` API 연동 (기업 상세 정보 조회)
- `/companies/:id/investments` API 연동 (기업 투자 목록 조회)
- `useEffect`를 활용한 데이터 fetching 로직 구현
- `useState`를 활용한 응답 데이터 상태 관리
- 기업 상세 정보 및 투자 목록 UI 렌더링 구현
- API 호출 시 `try-catch`를 활용한 에러 처리 로직 추가
- 리스트 페이지에 `loading` 상태 추가 및 로딩 분기 처리 구현
- ***

## 🔧 변경 사항

- 기업 상세페이지에서 목업 데이터 → 실제 API 데이터로 변경
- `Promise.all`을 활용하여 기업 정보와 투자 정보를 동시에 조회하도록 개선
- `res.ok` 체크를 통해 API 응답 검증 로직 추가
- 리스트 페이지에 `loading` state 추가 및 비동기 처리 구조 개선
- 기존 단순 fetch → `try-catch-finally` 구조로 변경하여 안정성 향상
- ***

## 🧪 테스트 방법

- 기업 목록 페이지 진입 시 정상적으로 데이터가 조회되는지 확인
- 기업 상세페이지 진입 시 기업 정보 및 투자 목록이 정상 렌더링되는지 확인
- 페이지네이션 클릭 시 투자 목록이 정상적으로 변경되는지 확인
- API 오류 발생 시 콘솔에 에러 로그 출력되는지 확인
- 로딩 상태에서 Skeleton 또는 로딩 UI가 정상적으로 표시되는지 확인
- ***

## 📸 스크린샷 (선택)

- 없음
- ***

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 에러 없음
- [x] 콘솔 경고 없음
- [x] 코드 컨벤션 준수
- [x] PR 제목 컨벤션 준수

---

## 🔗 관련 이슈

- close #30 