### PR TITLE
fix: 투자현황 리스트오류해결

### DIFF
--- a/FE/src/pages/investment/list.jsx
+++ b/FE/src/pages/investment/list.jsx
@@ -40,7 +40,7 @@ const List = ({ investmentList }) => {
 
               <td>View My Startup 투자 금액 원</td>
 
-              <td>{investment.totalInvestment.toLocaleString()}원</td>
+              <td>{investment?.totalInvestment?.toLocaleString()}원</td>
             </tr>
           ))}
         </tbody>


### PR DESCRIPTION
## 📌 개요

투자현황 리스트 안보이던 오류 수정


- ***

## ✨ 작업 내용

<!-- 구현한 기능 상세 -->

- useEffect로 데이터를 불러오기전에 toLocaleString() 사용으로 오류가남.


## 🔧 변경 사항

<!-- 기존 코드에서 무엇이 바뀌었는지 -->

- investment?.totalInvestment?.toLocaleString() 옵셔널 체이닝으로 해결

## 🧪 테스트 방법

<!-- 어떻게 테스트했는지 (중요) -->

- 수정후 리스트가 잘보이는지 확인



## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 에러 없음
- [x] 콘솔 경고 없음
- [x] 코드 컨벤션 준수
- [x] PR 제목 컨벤션 준수

---

## 🔗 관련 이슈

<!-- ex) close #1 -->

- close #
