### PR TITLE
feat: 로그인 및 회원가입 시 모달 표시, 메인 페이지로 이동

### DIFF
--- a/FE/src/pages/auth/Auth.jsx
+++ b/FE/src/pages/auth/Auth.jsx
@@ -1,4 +1,6 @@
 import { useState, useRef, useEffect } from "react";
+import { useLocation, useNavigate } from "react-router-dom";
+import AlertModal from "../../components/modal/AlertModal";
 import "../../styles/Auth.css";
 
 const EMAIL_REGEX = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
@@ -23,9 +25,13 @@ export default function Auth({ onLoginSuccess }) {
   const [email, setEmail] = useState("");
   const [nameError, setNameError] = useState("");
   const [emailError, setEmailError] = useState("");
+  const [successMessage, setSuccessMessage] = useState("");
 
   const nameRef = useRef(null);
   const emailRef = useRef(null);
+  const navigate = useNavigate();
+  const location = useLocation();
+  const redirectPath = location.state?.from?.pathname || "/";
 
   useEffect(() => {
     const user = getStoredUser();
@@ -70,16 +76,25 @@ export default function Auth({ onLoginSuccess }) {
 
   const handleConfirm = () => {
     if (!validate()) return;
+
     const user = { name: name.trim(), email: email.trim() };
     saveUser(user);
     onLoginSuccess?.(user);
+    setSuccessMessage("로그인이 됐습니다.");
   };
 
   const handleSignup = () => {
     if (!validate()) return;
+
     const user = { name: name.trim(), email: email.trim() };
     saveUser(user);
     onLoginSuccess?.(user);
+    setSuccessMessage("회원가입이 됐습니다.");
+  };
+
+  const handleSuccessModalClose = () => {
+    setSuccessMessage("");
+    navigate(redirectPath, { replace: true });
   };
 
   return (
@@ -156,6 +171,11 @@ export default function Auth({ onLoginSuccess }) {
           )}
         </div>
       </div>
+      <AlertModal
+        isOpen={Boolean(successMessage)}
+        message={successMessage}
+        onClose={handleSuccessModalClose}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## 📌 개요

<!-- 어떤 작업인지 간단하게 작성 -->

- 로그인 및 회원가입 시 모달 표시, 메인 페이지로 이동

## ✨ 작업 내용

<!-- 구현한 기능 상세 -->

- 로그인 성공 시 성공 모달 표시
- 회원가입 성공 시 성공 모달 표시
- 성공 모달 확인 버튼 클릭 시 이전 접근 페이지 또는 메인 페이지로 이동

## 🧪 테스트 방법

<!-- 어떻게 테스트했는지 (중요) -->

- auth.jsx 수정 후 npm run dev를 하여 테스트
- 로그인 정보가 남아있는 경우 개발자도구 - 애플리케이션 - 로컬 스토리지 - mystartup_user 삭제 후 다시 테스트 진행

## 📸 스크린샷 (선택)

<!-- UI 변경 시 첨부 -->

- ***

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 에러 없음
- [x] 콘솔 경고 없음
- [x] 코드 컨벤션 준수
- [x] PR 제목 컨벤션 준수

---

## 🔗 관련 이슈

<!-- ex) close #1 -->

- close #
