### PR TITLE
feat: 404 NotFound 페이지 및 예외 라우팅 추가

### DIFF
--- a/FE/src/App.jsx
+++ b/FE/src/App.jsx
@@ -9,6 +9,7 @@ import InvestmentPage from "./pages/investment/InvestmentPage";
 import Detail from "./pages/company/detail";
 import CompareSelectPage from "./pages/compare/CompareSelectPage";
 import Result from "./pages/compare/result";
+import NotFound from "./pages/NotFound";
 
 function App() {
   return (
@@ -23,6 +24,8 @@ function App() {
         <Route path="/investments" element={<InvestmentPage />} />
         <Route path="/companies/:id" element={<Detail />} />
         <Route path="/auth" element={<Auth />} />
+
+        <Route path="*" element={<NotFound />} />
       </Routes>
     </>
   );

--- a/FE/src/pages/NotFound.jsx
+++ b/FE/src/pages/NotFound.jsx
@@ -1,0 +1,18 @@
+import { useNavigate } from "react-router-dom";
+import "../styles/NotFound.css";
+
+const NotFound = () => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="notfound-container">
+      <h1>404</h1>
+      <h2>페이지를 찾을 수 없습니다</h2>
+      <p>요청하신 페이지가 존재하지 않거나 이동되었습니다.</p>
+
+      <button onClick={() => navigate("/")}>메인 페이지로 이동</button>
+    </div>
+  );
+};
+
+export default NotFound;

--- a/FE/src/styles/NotFound.css
+++ b/FE/src/styles/NotFound.css
@@ -1,0 +1,109 @@
+.notfound-container {
+  min-height: 80vh;
+  padding: 40px 20px;
+  display: flex;
+  flex-direction: column;
+  justify-content: center;
+  align-items: center;
+  gap: 16px;
+  text-align: center;
+  box-sizing: border-box;
+  background-color: #111;
+}
+
+.notfound-container h1 {
+  font-size: 96px;
+  font-weight: 700;
+  margin: 0;
+  line-height: 1;
+  color: #ffffff;
+}
+
+.notfound-container h2 {
+  font-size: 32px;
+  margin: 0;
+  word-break: keep-all;
+  color: #f5f5f5;
+}
+
+.notfound-container p {
+  font-size: 16px;
+  color: #bdbdbd;
+  margin: 0 0 20px;
+  word-break: keep-all;
+}
+
+.notfound-container button {
+  padding: 12px 24px;
+  border: 1px solid #2a2a2a;
+  border-radius: 8px;
+  background: #ffffff;
+  color: #111;
+  cursor: pointer;
+  font-size: 16px;
+  font-weight: 600;
+  transition: 0.2s;
+}
+
+.notfound-container button:hover {
+  background: #f3f3f3;
+  transform: translateY(-2px);
+}
+
+/* 태블릿 */
+@media (max-width: 768px) {
+  .notfound-container {
+    min-height: 70vh;
+    padding: 32px 16px;
+    gap: 14px;
+  }
+
+  .notfound-container h1 {
+    font-size: 72px;
+  }
+
+  .notfound-container h2 {
+    font-size: 24px;
+  }
+
+  .notfound-container p {
+    font-size: 15px;
+  }
+
+  .notfound-container button {
+    width: 100%;
+    max-width: 280px;
+    font-size: 15px;
+    padding: 12px 20px;
+  }
+}
+
+/* 모바일 */
+@media (max-width: 480px) {
+  .notfound-container {
+    min-height: 65vh;
+    padding: 24px 12px;
+    gap: 12px;
+  }
+
+  .notfound-container h1 {
+    font-size: 56px;
+  }
+
+  .notfound-container h2 {
+    font-size: 20px;
+  }
+
+  .notfound-container p {
+    font-size: 14px;
+    line-height: 1.6;
+  }
+
+  .notfound-container button {
+    width: 100%;
+    max-width: 240px;
+    font-size: 14px;
+    padding: 10px 16px;
+    border-radius: 6px;
+  }
+}


### PR DESCRIPTION
## 📌 개요

- 잘못된 URL 접근 시 사용자에게 안내를 제공하는 404 NotFound 페이지를 추가했습니다.
- 존재하지 않는 경로에 접근하면 자동으로 NotFound 페이지가 렌더링되도록 예외 라우팅을 설정했습니다.

---

## ✨ 작업 내용

- NotFound 페이지 컴포넌트 생성
- `path="*"` 라우트를 추가하여 404 페이지 연결
- 메인 페이지(`/`)로 이동할 수 있는 버튼 구현
- 반응형 CSS 적용 및 모바일/태블릿 대응
- 다크 테마에 맞는 UI 스타일 적용

---

## 🔧 변경 사항

- `App.jsx`에 `NotFound` 컴포넌트 import 및 예외 라우트 추가
- `pages/NotFound.jsx` 신규 생성
- `pages/NotFound.css` 신규 생성
- 기존 존재하지 않는 경로 접근 시 처리되지 않던 부분 개선

---

## 🧪 테스트 방법

- 존재하지 않는 URL 직접 입력 후 404 페이지 렌더링 확인
- 메인 페이지 이동 버튼 클릭 시 `/` 정상 이동 확인
- 모바일/태블릿 화면에서 반응형 UI 정상 동작 확인

---

## 📸 스크린샷 (선택)

- 필요 시 첨부 예정

---

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 에러 없음
- [x] 콘솔 경고 없음
- [x] 코드 컨벤션 준수
- [x] PR 제목 컨벤션 준수

---

## 🔗 관련 이슈

- close #71 