### PR TITLE
feat: 나의기업 선택취소 이상현상수정

### DIFF
--- a/FE/src/pages/compare/CompareSelectPage.jsx
+++ b/FE/src/pages/compare/CompareSelectPage.jsx
@@ -62,7 +62,6 @@ const CompareSelectPage = () => {
     try {
       await deleteMyCompany(USER_ID, myCompany.id);
       setMyCompany(null);
-      setCompareCompanies([]);
     } catch (err) {
       console.error(err);
     }


### PR DESCRIPTION
## 📌 개요

<!-- 어떤 작업인지 간단하게 작성 -->

- 나의 기업 비교 페이지에서 선택기업 선택 취소 시에 하단 비교기업부분이 사라지는 현상이 발견됐습니다.
- 그래서 선택기업 선택취소 시에 선택기업만 사라지게 수정


## 🔧 변경 사항

<!-- 기존 코드에서 무엇이 바뀌었는지 -->

- 선택기업 선택 취소시 하단 비교기업배열도 비우는 코드를 삭제
-
- ***

## 🧪 테스트 방법

<!-- 어떻게 테스트했는지 (중요) -->

- 코드수정후 기존 이상현상을 발견한 루트와 똑같이 테스트
- ***


## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 에러 없음
- [x] 콘솔 경고 없음
- [x] 코드 컨벤션 준수
- [x] PR 제목 컨벤션 준수

---

## 🔗 관련 이슈

<!-- ex) close #1 -->

- close #75 
