### PR TITLE
feat: 트렌드 현황 페이지 추가 및 API 연동

### DIFF
--- a/FE/src/App.jsx
+++ b/FE/src/App.jsx
@@ -10,6 +10,7 @@ import Detail from "./pages/company/detail";
 import CompareSelectPage from "./pages/compare/CompareSelectPage";
 import Result from "./pages/compare/result";
 import NotFound from "./pages/NotFound";
+import TrendPage from "./pages/trend/TrendPage";
 
 function App() {
   return (
@@ -24,6 +25,7 @@ function App() {
         <Route path="/investments" element={<InvestmentPage />} />
         <Route path="/companies/:id" element={<Detail />} />
         <Route path="/auth" element={<Auth />} />
+        <Route path="/trend" element={<TrendPage />} />
 
         <Route path="*" element={<NotFound />} />
       </Routes>

--- a/FE/src/components/layout/ListLayout.jsx
+++ b/FE/src/components/layout/ListLayout.jsx
@@ -12,6 +12,7 @@ function ListLayout({
   search,
   onSearchChange,
   onSearchSubmit,
+  showSearch = true,
 }) {
   return (
     <div className="layout-wrapper">
@@ -20,11 +21,13 @@ function ListLayout({
           <h2 className="layout-list-title">{title}</h2>
 
           <div className="layout-list-controls">
-            <SearchBar
-              value={search}
-              onChange={onSearchChange}
-              onSubmit={onSearchSubmit}
-            />
+            {showSearch && (
+              <SearchBar
+                value={search}
+                onChange={onSearchChange}
+                onSubmit={onSearchSubmit}
+              />
+            )}
 
             <SelectedList variant={sortVariant} onSortChange={onSortChange} />
           </div>

--- a/FE/src/components/layout/ProtectedLayout.jsx
+++ b/FE/src/components/layout/ProtectedLayout.jsx
@@ -1,5 +1,4 @@
 import { Navigate } from "react-router-dom";
-import { getStoredUser } from "../../pages/auth/Auth";
 import ListLayout from "./ListLayout";
 import useUserStore from "../../store/userStore";
 

--- a/FE/src/components/layout/header.jsx
+++ b/FE/src/components/layout/header.jsx
@@ -27,6 +27,9 @@ function Header() {
           <NavLink to="/investments" className="header-menu-name">
             투자 현황
           </NavLink>
+          <NavLink to="/trend" className="header-menu-name">
+            트렌드 현황
+          </NavLink>
         </div>
       </div>
     </header>

--- a/FE/src/components/search/SelectedList.jsx
+++ b/FE/src/components/search/SelectedList.jsx
@@ -32,6 +32,17 @@ const SORT_VARIANTS = {
       value: "baseInvestment_asc",
     },
   ],
+  TREND_SELECTION: [
+    { label: "최근 1일", value: "Today" },
+    {
+      label: "최근 7일",
+      value: "7days",
+    },
+    {
+      label: "최근 30일",
+      value: "Month",
+    },
+  ],
 };
 
 function SelectedList({ variant = "INVESTMENT", onSortChange, value }) {

--- a/FE/src/hook/useListPage.js
+++ b/FE/src/hook/useListPage.js
@@ -2,7 +2,7 @@ import { useEffect, useState } from "react";
 import useDebounce from "./useDebounce";
 import { getCompanies } from "../services/companyApi";
 
-function useCompanyList(initialSort) {
+function useCompanyList(initialSort, fetchApi = getCompanies) {
   const [loading, setLoading] = useState(true);
   const [list, setList] = useState([]);
   const [currentPage, setCurrentPage] = useState(1);
@@ -32,7 +32,7 @@ function useCompanyList(initialSort) {
         setLoading(true);
         setError(null);
 
-        const result = await getCompanies({
+        const result = await fetchApi({
           page: currentPage,
           limit: 10,
           sort,
@@ -57,7 +57,7 @@ function useCompanyList(initialSort) {
     };
 
     fetchData();
-  }, [currentPage, sort, debouncedSearch]);
+  }, [currentPage, sort, debouncedSearch, fetchApi]);
 
   return {
     loading,

--- a/FE/src/pages/trend/TrendList.jsx
+++ b/FE/src/pages/trend/TrendList.jsx
@@ -1,0 +1,58 @@
+import { useNavigate } from "react-router-dom";
+
+const TrendList = ({ companyList }) => {
+  const navigate = useNavigate();
+
+  return (
+    <div className="startup-table-wrap">
+      <table className="startup-table mb-4">
+        <thead className="startup-table-head">
+          <tr>
+            <th>순위</th>
+            <th>기업 명</th>
+            <th>기업 소개</th>
+            <th>카테고리</th>
+            <th>누적 투자 금액</th>
+            <th>투자 수</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr className="startup-table-dummy"></tr>
+        </tbody>
+        <tbody className="startup-table-body">
+          {companyList?.length === 0 ? (
+            <tr>
+              <td colSpan="6">조건에 맞는 결과가 없습니다</td>
+            </tr>
+          ) : (
+            companyList.map((company) => (
+              <tr
+                key={company.id}
+                className="startup-table-row cursor-pointer"
+                onClick={() => navigate(`/companies/${company.id}`)}
+              >
+                <td>{company.rank}위</td>
+
+                <td className="company-cell">
+                  <img
+                    src={company.logo || "https://placehold.co/50"}
+                    alt={company.name}
+                    className="company-logo"
+                  />
+                  <span>{company.name}</span>
+                </td>
+
+                <td className="desc-cell">{company.description}</td>
+                <td>{company.category || "-"}</td>
+                <td>{company.baseInvestment?.toLocaleString() || 0}원</td>
+                <td>{company.recentInvestmentCount}</td>
+              </tr>
+            ))
+          )}
+        </tbody>
+      </table>
+    </div>
+  );
+};
+
+export default TrendList;

--- a/FE/src/pages/trend/TrendPage.jsx
+++ b/FE/src/pages/trend/TrendPage.jsx
@@ -1,0 +1,47 @@
+import React from "react";
+import ProtectedLayout from "../../components/layout/ProtectedLayout";
+import ListSkeleton from "../../components/ui/ListSkeleton";
+import useListPage from "../../hook/useListPage";
+import TrendList from "./TrendList";
+import Pagination from "../../components/pagination/Pagination";
+import { getTrends } from "../../services/trendApi";
+
+const TrendPage = () => {
+  const {
+    loading,
+    list: companyList,
+    meta,
+    setCurrentPage,
+    setSort,
+    search,
+    setSearch,
+    handleSearchSubmit,
+  } = useListPage("7days", getTrends);
+
+  return (
+    <ProtectedLayout
+      title="트렌드 현황"
+      sortVariant="TREND_SELECTION"
+      onSortChange={setSort}
+      search={search}
+      onSearchChange={setSearch}
+      onSearchSubmit={handleSearchSubmit}
+      showSearch={false}
+    >
+      {loading ? (
+        <ListSkeleton />
+      ) : (
+        <>
+          <TrendList companyList={companyList} />
+          <Pagination
+            currentPage={meta.page}
+            totalPages={meta.totalPages}
+            onPageChange={setCurrentPage}
+          />
+        </>
+      )}
+    </ProtectedLayout>
+  );
+};
+
+export default TrendPage;

--- a/FE/src/services/trendApi.js
+++ b/FE/src/services/trendApi.js
@@ -1,0 +1,16 @@
+const BASE_URL = import.meta.env.VITE_API_BASE_URL;
+
+export async function request(endpoint, options = {}) {
+  const res = await fetch(`${BASE_URL}${endpoint}`, options);
+  const text = await res.text();
+
+  if (!res.ok) {
+    throw new Error(`데이터 요청 실패: ${res.status}`);
+  }
+
+  return JSON.parse(text);
+}
+
+export async function getTrends({ page = 1, limit = 10, sort }) {
+  return request(`/companies/trending?days=${sort}page=${page}&limit=${limit}`);
+}


### PR DESCRIPTION
## 📌 개요

- 트렌드 현황 페이지를 추가하고 트렌드 기업 리스트를 조회할 수 있도록 구현

***

## ✨ 작업 내용

- 트렌드 현황 리스트 화면 작성
- 헤더에 트렌드 페이지 링크 추가 및 연결
- App.jsx에 트렌드 페이지 라우트 연결
- trendApi.js에서 트렌드 API 연결 처리
- 트렌드 페이지 검색창 비노출 처리

***

## 🔧 변경 사항

- useListPage 훅에서 API 함수를 주입받을 수 있도록 수정
- 기존 getCompanies 고정 호출 구조를 getTrends 사용 가능하도록 개선
- ListLayout에 showSearch 분기 처리 추가

***

## 🧪 테스트 방법

- 헤더 클릭 시 트렌드 페이지 정상 이동 확인
- 트렌드 리스트 데이터 정상 조회 확인
- 검색창 미노출 및 정렬 기능 정상 동작 확인

***

## 📸 스크린샷 (선택)

- 없음

***

## ✅ 체크리스트

- [x] 정상 동작 확인
- [x] 에러 없음
- [x] 콘솔 경고 없음
- [x] 코드 컨벤션 준수
- [x] PR 제목 컨벤션 준수

---

## 🔗 관련 이슈

- close #79 